### PR TITLE
Fix use of undefined variable in shell script

### DIFF
--- a/Notes/snippets/shell-example-process-files.sh
+++ b/Notes/snippets/shell-example-process-files.sh
@@ -16,7 +16,7 @@ while IFS= read -r line; do
   # 检查 model_id 是否已经出现过
   if [[ ! "${seen_model_ids[@]}" =~ "${model_id}" ]]; then
     seen_model_ids+=("$model_id")
-    echo "$line" >> "$new_file_list"
+    echo "$line" >> "$unique_file"
   fi
 done < "$original_file"
 


### PR DESCRIPTION
`Notes/snippets/shell-example-process-files.sh` appends to an undefined variable (with `>> "$new_file_list"`) and also reads from a deleted file (`< "$unique_file"`). It seems to me that `"$new_file_list"` should have been `"$unique_file"`, which is what this PR changes.